### PR TITLE
fix typo

### DIFF
--- a/writing-migrations-working-with-tables.md
+++ b/writing-migrations-working-with-tables.md
@@ -143,7 +143,7 @@ class MyNewMigration extends AbstractMigration
 }
 ```
 
-另外，MySQL adapter 支持一下选项
+另外，MySQL adapter 支持以下选项
 
 | 选项 | 描述 |
 | :--- | :--- |


### PR DESCRIPTION
原文是 `In addition, the MySQL adapter supports following options`，`following` 译作 `以下` 比较合适。
原译文中的 `一下` 推测应该是笔误。